### PR TITLE
FIX: Use ampersand for logical and

### DIFF
--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -18,7 +18,7 @@ on:
         description: "Tag of built 'nightwatch' image"
         value: ${{ jobs.build.outputs.tag }}
 env:
-  set_versions: ${{ inputs.versions and github.ref_name == 'main' }}
+  set_versions: ${{ inputs.versions && github.ref_name == 'main' }}
 jobs:
   build:
     name: Build docker image


### PR DESCRIPTION
@AWieczorreck hatte in den Nightwatchtest diesen Fehler entdeckt https://github.com/ZeitOnline/zoca/actions/runs/5043922892

Wir müssen an der Stelle `&&` für das logische und benutzen.