### PR TITLE
feat(nightwatch): authenticate git push as zon-ops

### DIFF
--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_REPO_ACCESS_PAT }}
       - name: Set tag
         id: tag
         run: date +tag=%Y%m%d%H%M%S >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This way, repositories with branch protection rules can add the `zon-ops` user with admin rights (or maybe declare a rule exception for that user, if that's possible?), so GHA can still push.