### PR TITLE
feat(release): integrate "release-please" action into build workflow

### DIFF
--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -33,6 +33,13 @@ on:
         required: false
         type: string
         default: .
+    outputs:
+      release_created:
+        description: Indicator if a release was created
+        value: ${{ jobs.test-and-push.outputs.release_created }}
+      tag_name:
+        description: Release version tag if any
+        value: ${{ jobs.test-and-push.outputs.tag_name }}
 env:
   COMPOSE_FILE: ${{ inputs.compose_file }}
 jobs:

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -115,27 +115,27 @@ jobs:
       # otherwise the image versions are updated for 'staging'
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
-        if: inputs.versions && steps.release.outputs.release_created == false
+        if: ${{ inputs.versions && !steps.release.outputs.release_created }}
         with:
           gpg_private_key: ${{ secrets.ZON_OPS_GPG_KEY_PRIVATE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Set up Kustomize
         uses: imranismail/setup-kustomize@v2
-        if: inputs.versions && steps.release.outputs.release_created == false
+        if: ${{ inputs.versions && !steps.release.outputs.release_created }}
       - name: Pull recent changes
-        if: ${{ inputs.versions && steps.release.outputs.release_created == false && github.ref_type == 'branch' }}
+        if: ${{ inputs.versions && !steps.release.outputs.release_created && github.ref_type == 'branch' }}
         run: |
           git pull
       - name: Set image tags
-        if: inputs.versions && steps.release.outputs.release_created == false
+        if: ${{ inputs.versions && !steps.release.outputs.release_created }}
         run: |
           cd ${{ inputs.versions }}
           for target in ${{ inputs.targets }}; do
             kustomize edit set image $target:${{ env.describe }}
           done
       - name: Commit and push image tags
-        if: inputs.versions && steps.release.outputs.release_created == false
+        if: ${{ inputs.versions && !steps.release.outputs.release_created }}
         run: |
           git commit -am "ci: update image versions (``${{ inputs.versions }}``)"
           git push

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -46,6 +46,7 @@ jobs:
       id-token: write
       contents: write
       checks: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,37 +95,42 @@ jobs:
           project_name: ${{ env.project }}
           environment: production     # needs 'production' service account
           gar_docker_auth: true
+      - name: Release please
+        id: release
+        uses: googleapis/release-please-action@v4
+        if: inputs.targets
       - name: Publish images
         if: inputs.targets
         run: |
+          version="${{ steps.release.outputs.release_created && steps.release.outputs.tag_name || env.describe }}"
           for target in ${{ inputs.targets }}; do
-            tag="${{ env.prefix }}-$target:${{ env.describe }}"
+            tag="${{ env.prefix }}-$target:$version"
             docker build --target $target --tag $tag ${{ inputs.docker_context }}
             docker push $tag
           done
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
-        if: inputs.versions
+        if: inputs.versions && steps.release.outputs.release_created == false
         with:
           gpg_private_key: ${{ secrets.ZON_OPS_GPG_KEY_PRIVATE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Set up Kustomize
         uses: imranismail/setup-kustomize@v2
-        if: inputs.versions
+        if: inputs.versions && steps.release.outputs.release_created == false
       - name: Pull recent changes
-        if: ${{ inputs.versions && github.ref_type == 'branch' }}
+        if: ${{ inputs.versions && steps.release.outputs.release_created == false && github.ref_type == 'branch' }}
         run: |
           git pull
       - name: Set image tags
-        if: inputs.versions
+        if: inputs.versions && steps.release.outputs.release_created == false
         run: |
           cd ${{ inputs.versions }}
           for target in ${{ inputs.targets }}; do
             kustomize edit set image $target:${{ env.describe }}
           done
       - name: Commit and push image tags
-        if: inputs.versions
+        if: inputs.versions && steps.release.outputs.release_created == false
         run: |
           git commit -am "ci: update image versions (``${{ inputs.versions }}``)"
           git push

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -9,9 +9,6 @@ on:
       project:
         required: false
         type: string
-      tag:
-        required: false
-        type: string
       targets:
         required: false
         type: string
@@ -85,13 +82,12 @@ jobs:
         id: vars
         run: |
           input="${{ inputs.project }}"
-          tag="${{ inputs.tag }}"
           repository="${{ github.repository }}"
           default="${repository##*/}"
           project="${input:-$default}"
           echo "project=$project" >> "$GITHUB_ENV"
           echo "prefix=${{ vars.GAR_DOCKER_REGISTRY }}/$project" >> "$GITHUB_ENV"
-          echo "describe=${tag:-$( git describe --tags )}" >> "$GITHUB_ENV"
+          echo "describe=$( git describe --tags )" >> "$GITHUB_ENV"
       - name: Setup auth
         id: baseproject
         uses: ZeitOnline/gh-action-baseproject@v0

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      # build images, run tests and handle artifacts
       - name: Build images
         run: |
           docker compose build ${{ inputs.service }}
@@ -76,6 +77,7 @@ jobs:
         with:
           name: artifacts
           path: ${{ inputs.artifacts }}*
+      # set up variables and auth
       - name: Set variables
         id: vars
         run: |
@@ -95,10 +97,12 @@ jobs:
           project_name: ${{ env.project }}
           environment: production     # needs 'production' service account
           gar_docker_auth: true
+      # update release pull request or create release (if merged)
       - name: Release please
         id: release
         uses: googleapis/release-please-action@v4
         if: inputs.targets
+      # publish images depending on release
       - name: Publish images
         if: inputs.targets
         run: |
@@ -108,6 +112,8 @@ jobs:
             docker build --target $target --tag $tag ${{ inputs.docker_context }}
             docker push $tag
           done
+      # in case of a release any versions should be set via `extra-files`
+      # otherwise the image versions are updated for 'staging'
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         if: inputs.versions && steps.release.outputs.release_created == false

--- a/.github/workflows/build-test-push.yaml
+++ b/.github/workflows/build-test-push.yaml
@@ -47,6 +47,9 @@ jobs:
       contents: write
       checks: write
       pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -71,7 +71,7 @@ jobs:
             customHeaders: '{"Content-Type": "application/json"}'
             data: '{"project": "${{ env.project }}", "environment": "${{ inputs.environment }}",
                 "version": "${{ inputs.version }}", "emoji": "${{ inputs.emoji }}",
-                "vcs_url": "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}",
+                "vcs_url": "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.version }}",
                 "changelog_url": "${{ github.server_url }}/${{ github.repository }}/blob/main/${{ inputs.changelog }}"}'
 
       - name: Post release time to prometheus

--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -14,7 +14,7 @@ on:
       changelog:
         required: false
         type: string
-        default: CHANGES.md
+        default: CHANGELOG.md
       emoji:
         required: false
         type: string


### PR DESCRIPTION
The "release-please" action is run after the images have been built and tested. This either creates or updates the release pull request or, in case it was merged, creates a release. After that the above images are tagged accordingly.

See https://medium.com/@koladilip/embracing-automation-in-versioning-the-power-of-release-please-github-action-4241bd8f3b54 and https://github.com/googleapis/release-please-action