### PR TITLE
feat(nightwatch): always mount the nighwatch secret, keeping it optional

### DIFF
--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -32,7 +32,11 @@ on:
         required: false
         type: string
         default: |
-          --overrides='{ "spec": { "serviceAccount": "baseproject" } }'
+          --override-type=json --overrides='[
+            {"op": "add", "path": "/spec/serviceAccount", "value": "baseproject"},
+            {"op": "add", "path": "/spec/containers/0/envFrom", "value": [{
+                "secretRef": {"name": "nightwatch-secrets", "optional": true}}]}
+          ]'
       versions:
         required: false
         type: string


### PR DESCRIPTION
This way, GHA behaves the same as ZeitOnline/kustomize:nightwatch, and clients that use the secret (and have no other customizations) don't have to override anything in their workflows.