### PR TITLE
feat(nightwatch)!: use `kustomize` to create test pods

### DIFF
--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -38,15 +38,11 @@ on:
       gke_cluster:
         required: false
         type: string
-      args:
+      kustomization:
+        description: directory containing the k8s test manifest
         required: false
         type: string
-        default: |
-          --override-type=json --overrides='[
-            {"op": "add", "path": "/spec/serviceAccount", "value": "baseproject"},
-            {"op": "add", "path": "/spec/containers/0/envFrom", "value": [{
-                "secretRef": {"name": "nightwatch-secrets", "optional": true}}]}
-          ]'
+        default: k8s/base/nightwatch/test
       versions:
         description: directory in which to run `kustomize edit set-image`
         required: false
@@ -117,8 +113,11 @@ jobs:
         if: github.ref_name != 'main'
         run: |
           TAG=${{ env.tag }}
+          cd ${{ inputs.kustomize }}
+          kustomize edit set namesuffix $TAG
+          kustomize edit set image nightwatch-test=${{ env.image }}:$TAG
           kubectl config set-context --current --namespace=${{ env.project }}
-          kubectl run nightwatch-test-$TAG --image=${{ env.image }}:$TAG --restart=Never ${{ inputs.args }}
+          kubectl create --kustomize .
           kubectl wait --for=condition=Ready --timeout=120s pods/nightwatch-test-$TAG
           kubectl logs --follow pods/nightwatch-test-$TAG
           sleep 10

--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -47,6 +47,7 @@ on:
         description: directory in which to run `kustomize edit set-image`
         required: false
         type: string
+        default: k8s/base/nightwatch/versions
       k8s_base:
         description: directory that contains a k8s manifest containing the final image name
         required: false
@@ -136,5 +137,6 @@ jobs:
       - name: Commit and push image tags
         if: ${{ inputs.versions && github.ref_name == 'main' }}
         run: |
-          git commit -am "ci: update image versions (``${{ inputs.versions }}``)"
+          git add ${{ inputs.versions }}
+          git commit -m "ci: update image versions (``${{ inputs.versions }}``)"
           git push

--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -34,7 +34,7 @@ on:
       environment:
         required: false
         type: string
-        default : staging
+        default: staging
       gke_cluster:
         required: false
         type: string

--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -38,6 +38,7 @@ on:
       gke_cluster:
         required: false
         type: string
+        default: main-staging-25-01
       kustomization:
         description: directory containing the k8s test manifest
         required: false

--- a/.github/workflows/nightwatch-build.yaml
+++ b/.github/workflows/nightwatch-build.yaml
@@ -115,7 +115,7 @@ jobs:
         if: github.ref_name != 'main'
         run: |
           TAG=${{ env.tag }}
-          cd ${{ inputs.kustomize }}
+          cd ${{ inputs.kustomization }}
           kustomize edit set namesuffix $TAG
           kustomize edit set image nightwatch-test=${{ env.image }}:$TAG
           kubectl config set-context --current --namespace=${{ env.project }}


### PR DESCRIPTION
This allows to provide a k8s manifest for the test pod without the cumbersome `--overrides` option. The manifest is expected to be in `k8s/base/nightwatch/test` by default.

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: nightwatch-test-
spec:
  restartPolicy: Never
  serviceAccount: baseproject
  containers:
    - name: nightwatch-test
      image: nightwatch-test
      args:
        - "--browser=firefox"
      env:
        - name: HTTPS_PROXY
          value: http://static-ip-proxy.ops.zeit.de:3128
```
