### PR TITLE
feat(k8s-tests): add reusable workflow to run k8s manifest tests

### DIFF
--- a/.github/workflows/k8s-tests.yaml
+++ b/.github/workflows/k8s-tests.yaml
@@ -1,0 +1,55 @@
+name: K8s tests
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Directory containing the pytest suite (with its own pyproject.toml)"
+        default: "k8s/tests"
+        required: false
+        type: string
+      uv-version:
+        description: "Version of uv to install"
+        default: "0.11.31"
+        required: false
+        type: string
+      project:
+        description: >-
+          GCP project name. When set, authenticate to Google Cloud and expose the
+          private pypi-zon index credentials to uv (needed once the test dependencies –
+          e.g. zeit.k8stesting – live on the private index). Leave empty for suites that
+          only use public dependencies.
+        default: ""
+        required: false
+        type: string
+jobs:
+  pytest:
+    name: Run k8s manifest tests
+    runs-on: zon-ubuntu-general-dind
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Authenticate to Google Cloud
+        id: baseproject
+        if: inputs.project != ''
+        uses: ZeitOnline/gh-action-baseproject@v0
+        with:
+          project_name: ${{ inputs.project }}
+          gar_docker_auth: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: ${{ inputs.uv-version }}
+
+      - uses: imranismail/setup-kustomize@53f941b41dca13ed61874bbc6b4b6e1562877530 # v3
+
+      - name: Run pytest
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          UV_INDEX_PYPI_ZON_USERNAME: oauth2accesstoken
+          UV_INDEX_PYPI_ZON_PASSWORD: ${{ steps.baseproject.outputs.gcloud_access_token }}
+        run: uv run --link-mode=copy pytest

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ jobs:
 - [**lefthook**](#lefthook) — Run pre-commit code checks via [Lefthook](https://github.com/evilmartians/lefthook)
 - [**pre-commit**](#pre-commit) — Run code checks via [pre-commit](https://pre-commit.com/)
 - [**k8s-validation**](#k8s-validation) — Validate Kubernetes manifests using [kubeval](https://www.kubeval.com/)
+- [**k8s-tests**](#k8s-tests) — Run the `pytest`-based assertions over the generated Kubernetes manifests
 - [**nightwatch-build**](#nightwatch-build) — Build, push and run Nightwatch smoke test images
 - [**release-notification**](#release-notification) — Notify Slack and Prometheus about deployments
 
@@ -186,6 +187,36 @@ Validates Kubernetes manifests by running `kubectl kustomize` for each environme
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
 | `environments` | no | `staging production` | Space-separated list of environments to validate (expects `k8s/<env>` directories) |
+
+---
+
+### k8s-tests
+
+Runs the `pytest`-based test suite that makes assertions about the generated Kubernetes
+manifests (rendered via `kustomize`). The suite lives in its own directory with its own
+`pyproject.toml` and typically builds on the [`zeit.k8stesting`](https://github.com/ZeitOnline/zeit.k8stesting)
+plugin, which contributes the shared policy tests. This complements [k8s-validation](#k8s-validation)
+(schema validation): validation checks that the manifests are *valid*, these tests check
+that they are *correct* for our conventions (variant `-pgXX` suffixes, placeholder
+replacement, PGSERVICE routing, …).
+
+#### Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `working-directory` | no | `k8s/tests` | Directory containing the pytest suite (with its own `pyproject.toml`) |
+| `uv-version` | no | `0.11.31` | Version of `uv` to install |
+| `project` | no | — | GCP project name. When set, authenticates to Google Cloud and exposes the private `pypi-zon` index credentials to `uv` (needed once the test dependencies live on the private index). Leave empty for suites that only use public dependencies. |
+
+#### Example
+
+``` yaml
+jobs:
+  k8s-tests:
+    uses: zeitonline/gh-action-workflows/.github/workflows/k8s-tests.yaml
+    with:
+      project: premium-services
+```
 
 ---
 


### PR DESCRIPTION
Add a reusable `k8s-tests.yaml` workflow that runs the pytest-based
assertions over the generated Kubernetes manifests (rendered via
kustomize). It complements the existing `k8s-validation` workflow:
validation checks that manifests are valid, these tests check that they
are correct for our conventions (variant `-pgXX` suffixes, placeholder
replacement, PGSERVICE routing, ...).

Inputs: `working-directory` (default `k8s/tests`), `uv-version` and an
optional `project` that enables private pypi-zon index auth for suites
whose test dependencies (e.g. zeit.k8stesting) live on the private index.

Part of LPS-581 (Vorlage fuer k8s Tests).
