### PR TITLE
fix(k8s-policy-tests): deterministic kustomize root via generated conftest

### DIFF
--- a/.github/workflows/k8s-policy-tests.yaml
+++ b/.github/workflows/k8s-policy-tests.yaml
@@ -131,7 +131,28 @@ jobs:
             > k8s/tests/pyproject.toml
           printf '%s\n' 'from zeit.k8stesting.testsuite import *  # noqa: F401,F403' \
             > k8s/tests/test_k8s.py
+          # conftest.py: kustomize_root_directory + kustomize_environment_names auf
+          # conftest-Ebene überschreiben -- das gewinnt DETERMINISTISCH gegen pytest-kustomize
+          # (Plugin-gegen-Plugin-Fixture-Reihenfolge ist nicht garantiert). Der Root wird aus
+          # der env-getriebenen Plugin-Fixture wiederverwendet.
+          printf '%s\n' \
+            'import os' \
+            '' \
+            'import pytest' \
+            '' \
+            'from zeit.k8stesting.plugin import kustomize_root_directory  # noqa: F401' \
+            '' \
+            '' \
+            '@pytest.fixture(scope="session")' \
+            'def kustomize_environment_names():' \
+            '    return os.environ.get("ZEIT_K8STESTING_ENVIRONMENTS", "").split() or [' \
+            '        "devel",' \
+            '        "staging",' \
+            '        "production",' \
+            '    ]' \
+            > k8s/tests/conftest.py
           echo "--- generated k8s/tests/pyproject.toml ---"; cat k8s/tests/pyproject.toml
+          echo "--- generated k8s/tests/conftest.py ---"; cat k8s/tests/conftest.py
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0


### PR DESCRIPTION
## Problem

The `k8s-policy-tests` reusable workflow generated an ephemeral suite that relied on
`zeit.k8stesting`'s `kustomize_root_directory` fixture overriding pytest-kustomize's
same-named plugin fixture. **Cross-plugin fixture-override order is not deterministic** — it
favored zeit.k8stesting locally but pytest-kustomize in CI, where its default
(`os.getcwd()/k8s`) won, so every test errored:

```
FileNotFoundError: .../k8s/tests/k8s
```

(seen on ZeitOnline/entitlements#233).

## Fix

Generate a `k8s/tests/conftest.py` that overrides the fixtures at **conftest scope**, which
deterministically beats plugin fixtures regardless of load order:

- re-exports the plugin's env-aware `kustomize_root_directory`
  (`ZEIT_K8STESTING_KUSTOMIZE_ROOT` → else `../overlays/`);
- defines `kustomize_environment_names` from `ZEIT_K8STESTING_ENVIRONMENTS`.

No `zeit.k8stesting` change/release needed (reuses the existing 0.2.x plugin fixture).

## Verified locally

Generated suite (pyproject + one-line test_k8s.py + this conftest) against entitlements'
overlays: **9 passed / 15 skipped / 0 errors**; `pytest --fixtures` confirms
`kustomize_root_directory` resolves from `conftest.py`.

## Follow-up (separate)

Upstream an env/ini config hook into `pytest-kustomize` so the root is configurable without a
same-named override — would remove the collision at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)